### PR TITLE
Support table in comment blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,28 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 # 1.5.0
 ### Added
-
+#### Disable command
 Disable extension command. This will let you disable the table mode and hides the status item.
+
+#### Tables in comment blocks
+Added support for tables in comment blocks.
+
+Currently, there is support for three types of comments:
+
+```
+#  | first | second |
+#  | a     | b      |
+
+//  | first | second |
+//  | a     | b      |
+
+/*
+ *  | first | second |
+ *  | a     | b      |
+ */
+```
+
+Tables at the block comment start are not supported at the moment.
 
 # 1.4.2 - 2021-10-22
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,5 +1,4 @@
 import * as vscode from 'vscode'
-import { isTableMode } from './context/context'
 import { Table, RowType, Stringifier, TableNavigator, Parser } from './ttTable'
 
 /**

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode'
+import { isTableMode } from './context/context'
 import { Table, RowType, Stringifier, TableNavigator, Parser } from './ttTable'
 
 /**

--- a/src/context/context.ts
+++ b/src/context/context.ts
@@ -18,6 +18,17 @@ export function registerContext(type: ContextType, title: string, statusItem?: v
     ctx.setState(false)
 }
 
+export function contextState(editor: vscode.TextEditor, type: ContextType) {
+    const ctx = contexts.get(type)
+    if (ctx) {
+        ctx.setState(false)
+
+
+        const editorState = state.get(editor.document.fileName) || []
+        state.set(editor.document.fileName, editorState.filter(x => x !== type))
+    }
+}
+
 export function enterContext(editor: vscode.TextEditor, type: ContextType) {
     const ctx = contexts.get(type)
     if (ctx) {
@@ -39,13 +50,17 @@ export function exitContext(editor: vscode.TextEditor, type: ContextType) {
 }
 
 export function toggleContext(editor: vscode.TextEditor, type: ContextType) {
-    const editorState = state.get(editor.document.fileName) || []
-    if (editorState.indexOf(ContextType.tableMode) >= 0) {
+    if (isTableMode(editor)) {
         exitContext(editor, type)
     }
     else {
         enterContext(editor, type)
     }
+}
+
+export function isTableMode(editor: vscode.TextEditor) {
+    const editorState = state.get(editor.document.fileName) || []
+    return editorState.indexOf(ContextType.tableMode) >= 0
 }
 
 export function restoreContext(editor: vscode.TextEditor) {

--- a/src/markdownParser.ts
+++ b/src/markdownParser.ts
@@ -17,9 +17,12 @@ const relaxedRowGrammar = `
     `
 
 const relaxedTableGrammar = `
-    Table         ::= Line+
-    Line          ::= WS* Row WS*
-    WS            ::= [#x20#x09#x0A#x0D]+   /* Space | Tab | \\n | \\r */
+    Table              ::= Line+
+    Line               ::= WS* (LineComment|BlockComment|HashComment)? WS* Row WS*
+    WS                 ::= [#x20#x09#x0A#x0D]+   /* Space | Tab | \\n | \\r */
+    LineComment        ::= #x2F #x2F             /* // */
+    BlockComment       ::= #x2A
+    HashComment        ::= #x23
     ${relaxedRowGrammar}
     `
 

--- a/src/ttMarkdown.ts
+++ b/src/ttMarkdown.ts
@@ -24,7 +24,10 @@ export class MarkdownParser implements tt.Parser {
         const result = new tt.Table()
         result.prefix = findTablePrefix(text, verticalSeparator)
 
-        const lines = text.split('\n').map(x => x.trim()).filter(x => x.startsWith(verticalSeparator))
+        const lines = text.split('\n').map(x => x.trim()) // .filter(x => x.startsWith(verticalSeparator))
+        if (lines.length === 0) {
+            return undefined
+        }
 
         for (const line of lines) {
             parseRelaxed(line, result)
@@ -152,9 +155,9 @@ export class MarkdownLocator implements tt.Locator {
             if (ln < 0 || ln >= reader.lineCount) {
                 return false
             }
-            const firstCharIdx = reader.lineAt(ln).firstNonWhitespaceCharacterIndex
-            const firstChar = reader.lineAt(ln).text[firstCharIdx]
-            return firstChar === '|'
+
+            const token = relaxedParser.getAST(reader.lineAt(ln).text)
+            return token !== null && token.errors.length === 0
         }
 
         let start = lineNr

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -37,14 +37,71 @@ suite('Commands', () => {
 
     test('Keep indent', async () => {
         const testCase =
-        `        | first | second |
-        |  blah blah | this is some text |`
+`        | first | second |
+        |  blah blah | this is some text |
+`
         const expected =
-        `        | first     | second            |
-        | blah blah | this is some text |`
-        
+`
+        | first     | second            |
+        | blah blah | this is some text |
+`
+
         await inTextEditor({language: 'markdown', content: testCase}, async (editor, document) => {
             move(editor, 0, 10)
+            await vscode.commands.executeCommand('text-tables.gotoNextCell')
+
+            assertDocumentText(document, expected)
+        })
+    })
+
+    test('Keep comment indent', async () => {
+        const testCase =
+` //       | first | second |
+ //       |  blah blah | this is some text |
+`
+        const expected =
+` //       | first     | second            |
+ //       | blah blah | this is some text |
+`
+
+        await inTextEditor({language: 'markdown', content: testCase}, async (editor, document) => {
+            move(editor, 0, 12)
+            await vscode.commands.executeCommand('text-tables.gotoNextCell')
+
+            assertDocumentText(document, expected)
+        })
+    })
+
+    test('Keep hash comment indent', async () => {
+        const testCase =
+` #       | first | second |
+ #       |  blah blah | this is some text |
+`
+        const expected =
+` #       | first     | second            |
+ #       | blah blah | this is some text |
+`
+
+        await inTextEditor({language: 'markdown', content: testCase}, async (editor, document) => {
+            move(editor, 0, 12)
+            await vscode.commands.executeCommand('text-tables.gotoNextCell')
+
+            assertDocumentText(document, expected)
+        })
+    })
+
+    test('Keep block comment indent', async () => {
+        const testCase =
+` *       | first | second |
+ *       |  blah blah | this is some text |
+`
+        const expected =
+` *       | first     | second            |
+ *       | blah blah | this is some text |
+`
+
+        await inTextEditor({language: 'markdown', content: testCase}, async (editor, document) => {
+            move(editor, 0, 12)
             await vscode.commands.executeCommand('text-tables.gotoNextCell')
 
             assertDocumentText(document, expected)
@@ -58,7 +115,7 @@ suite('Commands', () => {
         const expected =
         `| A  | B  |
 | -1 | -1 |`
-        
+
         await inTextEditor({language: 'markdown', content: testCase}, async (editor, document) => {
             move(editor, 0, 1)
             await vscode.commands.executeCommand('text-tables.gotoNextCell')
@@ -87,7 +144,7 @@ suite('Commands', () => {
 '| ----- | ----- |'
 
         await inTextEditor({language: 'markdown', content: testCase}, async (editor, document) => {
-            
+
             await vscode.commands.executeCommand('text-tables.clearCell')
             move(editor, 0, 2)
             await vscode.commands.executeCommand('text-tables.clearCell')
@@ -121,7 +178,7 @@ suite('Commands', () => {
         ]
 
         await inTextEditor({language: 'markdown', content: input}, async (editor, document) => {
-            
+
             for (const t of testCases) {
                 await vscode.commands.executeCommand('text-tables.gotoNextCell')
                 assert.deepEqual(editor.selection.start, t)
@@ -236,7 +293,7 @@ suite('Commands', () => {
         ]
 
         await inTextEditor({language: 'markdown', content: input}, async (editor, document) => {
-            
+
             move(editor, 0, 2)
             for (const expected of steps) {
                 await vscode.commands.executeCommand('text-tables.moveColRight')
@@ -262,7 +319,7 @@ suite('Commands', () => {
         ]
 
         await inTextEditor({language: 'markdown', content: input}, async (editor, document) => {
-            
+
             move(editor, 0, 10)
             for (const expected of steps) {
                 await vscode.commands.executeCommand('text-tables.moveColLeft')
@@ -281,7 +338,7 @@ suite('Commands', () => {
 | 4 | 5 | 6 |`
 
         await inTextEditor({language: 'markdown', content: input}, async (_, document) => {
-            
+
 
             await vscode.commands.executeCommand('text-tables.formatUnderCursor')
             assertDocumentText(document, expected)
@@ -300,7 +357,7 @@ suite('Commands', () => {
 | 4   | 5   | 6   |`
 
         await inTextEditor({language: 'markdown', content: input}, async (_, document) => {
-            
+
 
             await vscode.commands.executeCommand('text-tables.formatUnderCursor')
             assertDocumentText(document, expected)
@@ -327,7 +384,7 @@ suite('Commands', () => {
         ]
 
         await inTextEditor({language: 'markdown', content: input}, async (editor, document) => {
-            
+
             move(editor, 0, 2)
             for (const expected of steps) {
                 await vscode.commands.executeCommand('text-tables.nextRow')

--- a/test/markdownParser.test.ts
+++ b/test/markdownParser.test.ts
@@ -3,7 +3,7 @@ import { IToken } from 'ebnf'
 import * as assert from 'assert'
 import { relaxedTableParser as parser} from '../src/markdownParser'
 import { MarkdownParser } from '../src/ttMarkdown'
-import {Alignment, Table} from '../src/ttTable'
+import { Alignment, Table } from '../src/ttTable'
 
 const cellContentOfTable = (ast: IToken) => {
     const result = []
@@ -74,8 +74,8 @@ suite('Markdown parser', () => {
         const parser = new MarkdownParser()
         const table = parser.parse(cleaned)
         assert.deepStrictEqual(cellContentOfttTable(table), [
-            ['A\\|B', 'C', 'D'], 
-            ['', '', ''], 
+            ['A\\|B', 'C', 'D'],
+            ['', '', ''],
             ['E', 'F', 'G']
         ])
     })
@@ -89,8 +89,8 @@ suite('Markdown parser', () => {
         const parser = new MarkdownParser()
         const table = parser.parse(cleaned)
         assert.deepStrictEqual(cellContentOfttTable(table), [
-            ['hi', 'there'], 
-            ['4', '\\|'], 
+            ['hi', 'there'],
+            ['4', '\\|'],
         ])
     })
 
@@ -106,7 +106,7 @@ suite('Markdown parser', () => {
         assert.deepStrictEqual(cellContentOfttTable(table), [
             ['a', 'b'],
             ['', ''],
-            ['c', 'd'], 
+            ['c', 'd'],
         ])
     })
 
@@ -122,7 +122,7 @@ suite('Markdown parser', () => {
         assert.deepStrictEqual(cellContentOfttTable(table), [
             ['a', 'b', ''],
             ['', '', ''],
-            ['c', 'd', ''], 
+            ['c', 'd', ''],
         ])
     })
 
@@ -140,5 +140,30 @@ suite('Markdown parser', () => {
         assert.equal(table!.cols[1].alignment, Alignment.left)
         assert.equal(table!.cols[2].alignment, Alignment.right)
         assert.equal(table!.cols[3].alignment, Alignment.center)
+    })
+
+    const assertParsed = (table: string, expected: any) => {
+        assert.deepStrictEqual(cellContentOfTable(parser.getAST(table)), expected)
+    }
+
+    test('parse table in line comment', () => {
+        assertParsed('//| A | B |\n', [[' A ', ' B ']])
+        assertParsed('// | A | B |\n', [[' A ', ' B ']])
+        assertParsed(' //| A | B |\n', [[' A ', ' B ']])
+        assertParsed(' // | A | B |\n', [[' A ', ' B ']])
+    })
+
+    test('parse table in block comment', () => {
+        assertParsed('*| A | B |\n', [[' A ', ' B ']])
+        assertParsed('* | A | B |\n', [[' A ', ' B ']])
+        assertParsed(' *| A | B |\n', [[' A ', ' B ']])
+        assertParsed(' * | A | B |\n', [[' A ', ' B ']])
+    })
+    
+    test('parse table in hash comment start', () => {
+        assertParsed('#| A | B |\n', [[' A ', ' B ']])
+        assertParsed('# | A | B |\n', [[' A ', ' B ']])
+        assertParsed(' #| A | B |\n', [[' A ', ' B ']])
+        assertParsed(' # | A | B |\n', [[' A ', ' B ']])
     })
 })


### PR DESCRIPTION
This will add support for tables in comment blocks.
See: https://github.com/rpeshkov/vscode-text-tables/issues/71

Currently, there is support for three types of comments:
```
#  | first | second |
#  | a     | b      |

//  | first | second |
//  | a     | b      |

/*
 *  | first | second |
 *  | a     | b      |
 */
```

Tables at the block comment start are not supported at the moment.
